### PR TITLE
Fix silent sketch/feature failures, mass-property fault, and missing validation module

### DIFF
--- a/src/solidedge_mcp/backends/features/_base.py
+++ b/src/solidedge_mcp/backends/features/_base.py
@@ -3,7 +3,9 @@ Base class for FeatureManager providing constructor and shared helpers.
 """
 
 import contextlib
+import functools
 import traceback
+from collections.abc import Callable
 from typing import Any
 
 import pythoncom
@@ -18,12 +20,113 @@ from ..logging import get_logger
 _logger = get_logger(__name__)
 
 
+def verifies_geometry(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorate a feature-creation method to confirm it actually built geometry.
+
+    Several Solid Edge COM feature calls silently no-op -- e.g. when the active
+    profile failed to close into a region -- yet they do not raise, so the
+    wrapped method returns ``status='created'`` with nothing built. This
+    decorator snapshots the ordered feature count before/after and, on apparent
+    success, downgrades the misleading result to an explicit error when the
+    count did not increase.
+
+    The check keys on the body's FACE COUNT (and Models.Count for the first
+    solid), NOT the feature-tree count -- a failed feature still adds a tree
+    node, so DesignEdgebarFeatures.Count is not a reliable geometry signal,
+    whereas a no-op leaves the body's face count unchanged. If those counts
+    cannot be read as ints (e.g. mocked tests, or no body), the decorator
+    passes the result through unchanged -- it never invents a failure it
+    cannot prove.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(self: "FeatureManagerBase", *args: Any, **kwargs: Any) -> Any:
+        before = self._geometry_snapshot()
+        result = fn(self, *args, **kwargs)
+        if not (isinstance(result, dict) and "error" not in result):
+            return result
+        after = self._geometry_snapshot()
+        if self._no_geometry_created(before, after):
+            _logger.warning(
+                f"{fn.__name__} reported success but the body did not change "
+                f"(models {before[0]}->{after[0]}, faces {before[1]}->{after[1]}); "
+                f"reporting as a no-geometry error."
+            )
+            return {
+                "error": (
+                    "Feature reported success but no geometry was created: the "
+                    "body's face count did not change. The sketch profile is most "
+                    "likely open/invalid -- close it as a closed region first -- "
+                    "or the operation had no effect on the body."
+                ),
+                "attempted": result.get("type"),
+                "models_before": before[0],
+                "models_after": after[0],
+                "faces_before": before[1],
+                "faces_after": after[1],
+            }
+        return result
+
+    return wrapper
+
+
 class FeatureManagerBase:
     """Base providing __init__ and helpers shared across feature mixins."""
 
     def __init__(self, document_manager: Any, sketch_manager: Any) -> None:
         self.doc_manager = document_manager
         self.sketch_manager = sketch_manager
+
+    def _geometry_snapshot(self) -> tuple[int | None, int | None]:
+        """Return (models_count, body_face_count); None for unreadable.
+
+        Used by @verifies_geometry to detect feature calls that silently
+        created nothing. face_count is 0 when no body exists yet, the body's
+        face count when one does, and None when it cannot be read (e.g. mocked
+        COM objects) so the check stays conservative. ``type(x) is int`` guards
+        against MagicMock values in unit tests.
+        """
+        try:
+            doc = self.doc_manager.get_active_document()
+        except Exception:
+            return (None, None)
+        # Geometry verification needs a real Solid Edge document. Against a
+        # unittest.mock double there is nothing real to measure (its counts are
+        # arbitrary), so stay inert rather than invent failures in unit tests.
+        if type(doc).__module__.startswith("unittest.mock"):
+            return (None, None)
+        models: int | None = None
+        faces: int | None = None
+        with contextlib.suppress(Exception):
+            count = doc.Models.Count
+            models = count if type(count) is int else None
+        if models == 0:
+            faces = 0  # no body yet -> definitively zero faces
+        elif models is not None and models > 0:
+            with contextlib.suppress(Exception):
+                body = doc.Models.Item(1).Body
+                fc = body.Faces(FaceQueryConstants.igQueryAll).Count
+                faces = fc if type(fc) is int else None
+        return (models, faces)
+
+    @staticmethod
+    def _no_geometry_created(
+        before: tuple[int | None, int | None],
+        after: tuple[int | None, int | None],
+    ) -> bool:
+        """True only when we can PROVE the operation changed no geometry.
+
+        Success is a new solid (Models.Count grew, the base feature) or a change
+        in the body's face count (any add/cut/round/chamfer/hole). When neither
+        can be read we return False -- never claim a failure we cannot prove.
+        """
+        mb, ma = before[0], after[0]
+        if mb is not None and ma is not None and ma > mb:
+            return False  # base solid appeared
+        fb, fa = before[1], after[1]
+        if fb is not None and fa is not None:
+            return fa == fb  # body unchanged -> nothing was built
+        return False
 
     def _get_ref_plane(self, doc: Any, plane_index: int = 1) -> Any:
         """Get a reference plane from the document (1=Top/XY, 2=Right/YZ, 3=Front/XZ)"""

--- a/src/solidedge_mcp/backends/features/_base.py
+++ b/src/solidedge_mcp/backends/features/_base.py
@@ -6,7 +6,7 @@ import contextlib
 import functools
 import traceback
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Concatenate, ParamSpec
 
 import pythoncom
 from win32com.client import VARIANT
@@ -19,16 +19,21 @@ from ..logging import get_logger
 
 _logger = get_logger(__name__)
 
+_P = ParamSpec("_P")
+# Decorated methods live on mixins that are not FeatureManagerBase subclasses
+# statically, so ``self`` is typed as Any here.
+_Creator = Callable[Concatenate[Any, _P], dict[str, Any]]
 
-def verifies_geometry(fn: Callable[..., Any]) -> Callable[..., Any]:
+
+def verifies_geometry(fn: _Creator[_P]) -> _Creator[_P]:
     """Decorate a feature-creation method to confirm it actually built geometry.
 
     Several Solid Edge COM feature calls silently no-op -- e.g. when the active
     profile failed to close into a region -- yet they do not raise, so the
     wrapped method returns ``status='created'`` with nothing built. This
-    decorator snapshots the ordered feature count before/after and, on apparent
+    decorator snapshots the body's geometry before/after and, on apparent
     success, downgrades the misleading result to an explicit error when the
-    count did not increase.
+    body did not change.
 
     The check keys on the body's FACE COUNT (and Models.Count for the first
     solid), NOT the feature-tree count -- a failed feature still adds a tree
@@ -40,7 +45,7 @@ def verifies_geometry(fn: Callable[..., Any]) -> Callable[..., Any]:
     """
 
     @functools.wraps(fn)
-    def wrapper(self: "FeatureManagerBase", *args: Any, **kwargs: Any) -> Any:
+    def wrapper(self: Any, /, *args: _P.args, **kwargs: _P.kwargs) -> dict[str, Any]:
         before = self._geometry_snapshot()
         result = fn(self, *args, **kwargs)
         if not (isinstance(result, dict) and "error" not in result):

--- a/src/solidedge_mcp/backends/features/_base.py
+++ b/src/solidedge_mcp/backends/features/_base.py
@@ -70,6 +70,22 @@ def verifies_geometry(fn: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
+def verify_geometry_on_creators(cls: type) -> type:
+    """Class decorator: wrap every ``create_*`` method with @verifies_geometry.
+
+    Apply only to mixins whose create_* methods ALL change the solid body
+    (add or remove material) -- extrude, revolve, holes, cutout, primitives.
+    Do NOT use on mixins with geometry-neutral creators (draft, cosmetic
+    thread, surface/ref-plane builders): a successful such op leaves the face
+    count unchanged and would be misreported as a no-op. Those need per-method
+    decoration with a deliberate skip-list instead.
+    """
+    for name, attr in list(vars(cls).items()):
+        if name.startswith("create_") and callable(attr):
+            setattr(cls, name, verifies_geometry(attr))
+    return cls
+
+
 class FeatureManagerBase:
     """Base providing __init__ and helpers shared across feature mixins."""
 

--- a/src/solidedge_mcp/backends/features/_cutout.py
+++ b/src/solidedge_mcp/backends/features/_cutout.py
@@ -13,11 +13,12 @@ from ..constants import (
     LoftSweepConstants,
 )
 from ..logging import get_logger
-from ._base import verifies_geometry
+from ._base import verify_geometry_on_creators
 
 _logger = get_logger(__name__)
 
 
+@verify_geometry_on_creators
 class CutoutMixin:
     """Mixin providing cutout/removal feature methods."""
 
@@ -79,7 +80,6 @@ class CutoutMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
-    @verifies_geometry
     def create_extruded_cutout(self, distance: float, direction: str = "Normal") -> dict[str, Any]:
         """
         Create an extruded cutout (cut) through the part using the active sketch profile.
@@ -127,7 +127,6 @@ class CutoutMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
-    @verifies_geometry
     def create_extruded_cutout_through_all(self, direction: str = "Normal") -> dict[str, Any]:
         """
         Create an extruded cutout that goes through the entire part.

--- a/src/solidedge_mcp/backends/features/_cutout.py
+++ b/src/solidedge_mcp/backends/features/_cutout.py
@@ -13,6 +13,7 @@ from ..constants import (
     LoftSweepConstants,
 )
 from ..logging import get_logger
+from ._base import verifies_geometry
 
 _logger = get_logger(__name__)
 
@@ -78,6 +79,7 @@ class CutoutMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
+    @verifies_geometry
     def create_extruded_cutout(self, distance: float, direction: str = "Normal") -> dict[str, Any]:
         """
         Create an extruded cutout (cut) through the part using the active sketch profile.
@@ -125,6 +127,7 @@ class CutoutMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
+    @verifies_geometry
     def create_extruded_cutout_through_all(self, direction: str = "Normal") -> dict[str, Any]:
         """
         Create an extruded cutout that goes through the entire part.

--- a/src/solidedge_mcp/backends/features/_extrude.py
+++ b/src/solidedge_mcp/backends/features/_extrude.py
@@ -8,6 +8,7 @@ from ..constants import (
     FeatureOperationConstants,
 )
 from ..logging import get_logger
+from ._base import verifies_geometry
 
 _logger = get_logger(__name__)
 
@@ -15,6 +16,7 @@ _logger = get_logger(__name__)
 class ExtrudeMixin:
     """Mixin providing extrude protrusion methods."""
 
+    @verifies_geometry
     def create_extrude(
         self, distance: float, operation: str = "Add", direction: str = "Normal"
     ) -> dict[str, Any]:
@@ -73,6 +75,7 @@ class ExtrudeMixin:
             _logger.error(f"Extrude failed: {e}")
             return {"error": str(e), "traceback": traceback.format_exc()}
 
+    @verifies_geometry
     def create_extrude_symmetric(self, distance: float) -> dict[str, Any]:
         """
         Create a symmetric extrusion (extends equally in both directions).

--- a/src/solidedge_mcp/backends/features/_extrude.py
+++ b/src/solidedge_mcp/backends/features/_extrude.py
@@ -8,15 +8,15 @@ from ..constants import (
     FeatureOperationConstants,
 )
 from ..logging import get_logger
-from ._base import verifies_geometry
+from ._base import verify_geometry_on_creators
 
 _logger = get_logger(__name__)
 
 
+@verify_geometry_on_creators
 class ExtrudeMixin:
     """Mixin providing extrude protrusion methods."""
 
-    @verifies_geometry
     def create_extrude(
         self, distance: float, operation: str = "Add", direction: str = "Normal"
     ) -> dict[str, Any]:
@@ -75,7 +75,6 @@ class ExtrudeMixin:
             _logger.error(f"Extrude failed: {e}")
             return {"error": str(e), "traceback": traceback.format_exc()}
 
-    @verifies_geometry
     def create_extrude_symmetric(self, distance: float) -> dict[str, Any]:
         """
         Create a symmetric extrusion (extends equally in both directions).

--- a/src/solidedge_mcp/backends/features/_holes.py
+++ b/src/solidedge_mcp/backends/features/_holes.py
@@ -8,15 +8,15 @@ from ..constants import (
     FaceQueryConstants,
 )
 from ..logging import get_logger
-from ._base import verifies_geometry
+from ._base import verify_geometry_on_creators
 
 _logger = get_logger(__name__)
 
 
+@verify_geometry_on_creators
 class HolesMixin:
     """Mixin providing hole creation methods."""
 
-    @verifies_geometry
     def create_hole(
         self,
         x: float,
@@ -81,7 +81,6 @@ class HolesMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
-    @verifies_geometry
     def create_hole_through_all(
         self, x: float, y: float, diameter: float, plane_index: int = 1, direction: str = "Normal"
     ) -> dict[str, Any]:

--- a/src/solidedge_mcp/backends/features/_holes.py
+++ b/src/solidedge_mcp/backends/features/_holes.py
@@ -8,6 +8,7 @@ from ..constants import (
     FaceQueryConstants,
 )
 from ..logging import get_logger
+from ._base import verifies_geometry
 
 _logger = get_logger(__name__)
 
@@ -15,6 +16,7 @@ _logger = get_logger(__name__)
 class HolesMixin:
     """Mixin providing hole creation methods."""
 
+    @verifies_geometry
     def create_hole(
         self,
         x: float,
@@ -79,6 +81,7 @@ class HolesMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
+    @verifies_geometry
     def create_hole_through_all(
         self, x: float, y: float, diameter: float, plane_index: int = 1, direction: str = "Normal"
     ) -> dict[str, Any]:

--- a/src/solidedge_mcp/backends/features/_loft_sweep.py
+++ b/src/solidedge_mcp/backends/features/_loft_sweep.py
@@ -12,12 +12,19 @@ from ..constants import (
     LoftSweepConstants,
 )
 from ..logging import get_logger
+from ._base import verify_geometry_on_creators
 
 _logger = get_logger(__name__)
 
 
+@verify_geometry_on_creators
 class LoftSweepMixin:
-    """Mixin providing loft, sweep, and helix protrusion methods."""
+    """Mixin providing loft, sweep, and helix protrusion methods.
+
+    All methods here are solid protrusions (loft/sweep/helix and their
+    thin-wall variants), so geometry verification applies uniformly. Surface
+    builders live in _surfaces.py and are intentionally excluded.
+    """
 
     def create_loft(self, profile_indices: list[int] | None = None) -> dict[str, Any]:
         """

--- a/src/solidedge_mcp/backends/features/_primitives.py
+++ b/src/solidedge_mcp/backends/features/_primitives.py
@@ -5,10 +5,12 @@ from typing import Any
 
 from ..constants import DirectionConstants
 from ..logging import get_logger
+from ._base import verify_geometry_on_creators
 
 _logger = get_logger(__name__)
 
 
+@verify_geometry_on_creators
 class PrimitiveMixin:
     """Mixin providing primitive solid creation methods."""
 

--- a/src/solidedge_mcp/backends/features/_revolve.py
+++ b/src/solidedge_mcp/backends/features/_revolve.py
@@ -16,6 +16,7 @@ from ..constants import (
     TreatmentTypeConstants,
 )
 from ..logging import get_logger
+from ._base import verifies_geometry
 
 _logger = get_logger(__name__)
 
@@ -23,6 +24,7 @@ _logger = get_logger(__name__)
 class RevolveMixin:
     """Mixin providing revolve protrusion methods."""
 
+    @verifies_geometry
     def create_revolve(self, angle: float = 360, operation: str = "Add") -> dict[str, Any]:
         """
         Create a revolve feature from the active sketch profile.
@@ -76,6 +78,7 @@ class RevolveMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
+    @verifies_geometry
     def create_revolve_finite(self, angle: float, axis_type: str = "CenterLine") -> dict[str, Any]:
         """
         Create a finite revolve feature.
@@ -281,6 +284,7 @@ class RevolveMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
+    @verifies_geometry
     def create_revolve_full(
         self, angle: float = 360.0, treatment_type: str = "None"
     ) -> dict[str, Any]:

--- a/src/solidedge_mcp/backends/features/_revolve.py
+++ b/src/solidedge_mcp/backends/features/_revolve.py
@@ -16,15 +16,15 @@ from ..constants import (
     TreatmentTypeConstants,
 )
 from ..logging import get_logger
-from ._base import verifies_geometry
+from ._base import verify_geometry_on_creators
 
 _logger = get_logger(__name__)
 
 
+@verify_geometry_on_creators
 class RevolveMixin:
     """Mixin providing revolve protrusion methods."""
 
-    @verifies_geometry
     def create_revolve(self, angle: float = 360, operation: str = "Add") -> dict[str, Any]:
         """
         Create a revolve feature from the active sketch profile.
@@ -78,7 +78,6 @@ class RevolveMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
-    @verifies_geometry
     def create_revolve_finite(self, angle: float, axis_type: str = "CenterLine") -> dict[str, Any]:
         """
         Create a finite revolve feature.
@@ -284,7 +283,6 @@ class RevolveMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
-    @verifies_geometry
     def create_revolve_full(
         self, angle: float = 360.0, treatment_type: str = "None"
     ) -> dict[str, Any]:

--- a/src/solidedge_mcp/backends/features/_rounds_chamfers.py
+++ b/src/solidedge_mcp/backends/features/_rounds_chamfers.py
@@ -10,6 +10,7 @@ from ..constants import (
     FaceQueryConstants,
 )
 from ..logging import get_logger
+from ._base import verifies_geometry
 
 _logger = get_logger(__name__)
 
@@ -17,6 +18,7 @@ _logger = get_logger(__name__)
 class RoundsChamfersMixin:
     """Mixin providing round, chamfer, and blend methods."""
 
+    @verifies_geometry
     def create_round(self, radius: float) -> dict[str, Any]:
         """
         Create a round (fillet) feature on all body edges.
@@ -79,6 +81,7 @@ class RoundsChamfersMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
+    @verifies_geometry
     def create_round_on_face(self, radius: float, face_index: int) -> dict[str, Any]:
         """
         Create a round (fillet) on edges of a specific face.
@@ -217,6 +220,7 @@ class RoundsChamfersMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
+    @verifies_geometry
     def create_chamfer(self, distance: float) -> dict[str, Any]:
         """
         Create an equal-setback chamfer on all body edges.
@@ -268,6 +272,7 @@ class RoundsChamfersMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
+    @verifies_geometry
     def create_chamfer_on_face(self, distance: float, face_index: int) -> dict[str, Any]:
         """
         Create a chamfer on edges of a specific face.
@@ -423,6 +428,7 @@ class RoundsChamfersMixin:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
+    @verifies_geometry
     def create_chamfer_angle(
         self, distance: float, angle: float, face_index: int = 0
     ) -> dict[str, Any]:

--- a/src/solidedge_mcp/backends/query/_physical_props.py
+++ b/src/solidedge_mcp/backends/query/_physical_props.py
@@ -29,7 +29,7 @@ class PhysicalPropsMixin(QueryManagerBase):
             Dict with volume, mass, surface area, center of gravity, moments of inertia
         """
         try:
-            _logger.info(f"Computing mass properties with density={density} kg/m³")
+            _logger.info(f"Computing mass properties with density={density} kg/m^3")
             doc, model = self._get_first_model()
 
             # ComputePhysicalPropertiesWithSpecifiedDensity(Density, Accuracy)

--- a/src/solidedge_mcp/backends/query/_physical_props.py
+++ b/src/solidedge_mcp/backends/query/_physical_props.py
@@ -267,39 +267,58 @@ class PhysicalPropsMixin(QueryManagerBase):
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
-    def get_user_physical_properties(self) -> dict[str, Any]:
+    def get_user_physical_properties(self, density: float = 7850.0) -> dict[str, Any]:
         """
-        Get user-overridden physical properties from the active part document.
+        Get physical properties of the active part.
 
-        Uses PartDocument.GetUserPhysicalProperties() which returns properties
-        that have been manually set via PutUserPhysicalProperties.
+        Prefers user-overridden values from PartDocument.GetUserPhysicalProperties()
+        (set via PutUserPhysicalProperties). On a part with no such overrides that
+        COM call FAULTS, so we fall back to properties COMPUTED from geometry via
+        ComputePhysicalPropertiesWithSpecifiedDensity (the same path the working
+        solidedge://geometry/* resources use). The returned dict carries a
+        ``source`` of "user_override" or "computed".
+
+        Args:
+            density: Density (kg/m³) used only for the computed fallback
+                (default 7850 = steel). Ignored when user overrides exist.
 
         Returns:
-            Dict with volume, area, mass, center of gravity, moments of inertia
+            Dict with volume, area, mass, center of gravity, etc.
         """
         try:
             doc = self.doc_manager.get_active_document()
-            result = doc.GetUserPhysicalProperties()
+            try:
+                result = doc.GetUserPhysicalProperties()
+            except Exception as e:
+                _logger.info(
+                    f"GetUserPhysicalProperties unavailable ({e}); "
+                    f"computing properties from geometry."
+                )
+                result = None
 
             # Result is a tuple: (Volume, Area, Mass, CoG[3], CoV[3],
             #   GlobalMOI[6], PrincipalMOI[3], PrincipalAxes[9], RadiiOfGyration[3])
-            props: dict[str, Any] = {"status": "success"}
             if isinstance(result, tuple) and len(result) >= 3:
+                props: dict[str, Any] = {"status": "success", "source": "user_override"}
                 props["volume"] = result[0]
                 props["surface_area"] = result[1]
                 props["mass"] = result[2]
-                if len(result) > 3:
-                    cog = result[3]
-                    if hasattr(cog, "__iter__"):
-                        props["center_of_gravity"] = list(cog)[:3]
-                if len(result) > 4:
-                    cov = result[4]
-                    if hasattr(cov, "__iter__"):
-                        props["center_of_volume"] = list(cov)[:3]
-            else:
-                props["raw_result"] = str(result)
+                if len(result) > 3 and hasattr(result[3], "__iter__"):
+                    props["center_of_gravity"] = list(result[3])[:3]
+                if len(result) > 4 and hasattr(result[4], "__iter__"):
+                    props["center_of_volume"] = list(result[4])[:3]
+                return props
 
-            return props
+            # No usable user-set overrides -> compute from geometry.
+            computed = self.get_mass_properties(density)
+            if "error" not in computed:
+                computed["source"] = "computed"
+                computed["note"] = (
+                    "No user-set physical properties were found; values were "
+                    f"computed from geometry at density={density} kg/m³. Assign a "
+                    "material/density for an exact mass."
+                )
+            return computed
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 

--- a/src/solidedge_mcp/backends/sketching.py
+++ b/src/solidedge_mcp/backends/sketching.py
@@ -749,7 +749,11 @@ class SketchManager:
         """
         Add a keypoint constraint connecting two sketch elements at specific points.
 
-        Keypoint indices: 0=start, 1=end for lines/arcs; 0=center for circles.
+        Keypoint indices are GEOMETRIC, 0-based: 0=start, 1=end, 2=midpoint for
+        lines/arcs; 0=center for circles. (Verified live: AddKeypoint(line, 1,
+        other, 0) welds line's end to other's start.) These are NOT the
+        KeyPointType enum values igKeyPointStart=1/igKeyPointEnd=2 -- that enum
+        belongs to other (extent/revolve) APIs and must not be used here.
 
         Args:
             element1_type: Type of first element ('line', 'circle', 'arc', etc.)

--- a/src/solidedge_mcp/backends/sketching.py
+++ b/src/solidedge_mcp/backends/sketching.py
@@ -783,23 +783,47 @@ class SketchManager:
         except Exception as e:
             return {"error": str(e), "traceback": traceback.format_exc()}
 
-    def close_sketch(self) -> dict[str, Any]:
-        """Close/finish the active sketch"""
+    def close_sketch(self, closed: bool = True) -> dict[str, Any]:
+        """Close/finish the active sketch and report whether it validated.
+
+        Profile.End(flags) returns 0 on success and a negative status code
+        when the profile fails validation (e.g. an open loop). We surface that
+        code instead of swallowing it, so callers can tell BEFORE building a
+        feature whether the profile actually forms a region.
+
+        Args:
+            closed: If True (default) the profile is validated as a CLOSED
+                region (igProfileClosed). This is required for solid features
+                and, crucially, welds the coincident endpoints of a polyline
+                (e.g. a rectangle drawn as 4 separate lines) into a single
+                region -- with the old igProfileDefault flag such polylines
+                silently produced no geometry. Set False for intentionally
+                open profiles (sweep paths, open surfaces).
+        """
         try:
             if not self.active_profile:
                 return {"error": "No active sketch to close"}
 
-            # Use correct End() flags based on whether axis of revolution is set
+            # Choose validation flags. A revolve profile already implies closed
+            # (igProfileForRevolve = igProfileClosed | igProfileRefAxisRequired).
             if self.active_refaxis is not None:
-                # Revolve profile needs igProfileClosed | igProfileRefAxisRequired
                 end_flags = ProfileValidationConstants.igProfileForRevolve  # 17
+            elif closed:
+                end_flags = ProfileValidationConstants.igProfileClosed  # 1
             else:
-                # Standard profile (extrude, etc.)
                 end_flags = ProfileValidationConstants.igProfileDefault  # 0
 
-            # Validate the profile
-            with contextlib.suppress(BaseException):
-                self.active_profile.End(end_flags)
+            # Validate the profile. End() returns a status: 0 = OK, < 0 = invalid.
+            # Do NOT suppress -- the validation result is the whole point.
+            try:
+                validation_code = self.active_profile.End(end_flags)
+            except Exception as e:
+                _logger.error(f"Profile.End({end_flags}) raised: {e}")
+                return {
+                    "error": f"Profile validation failed: {e}",
+                    "end_flags": end_flags,
+                    "traceback": traceback.format_exc(),
+                }
 
             # Add to accumulated profiles for loft/sweep operations
             self.accumulated_profiles.append(self.active_profile)
@@ -807,12 +831,26 @@ class SketchManager:
             sketch_id = "sketch"
             if self.active_sketch is not None and hasattr(self.active_sketch, "Name"):
                 sketch_id = self.active_sketch.Name
-            result = {
+            result: dict[str, Any] = {
                 "status": "closed",
+                "validation_code": validation_code,
                 "sketch_id": sketch_id,
                 "has_revolution_axis": self.active_refaxis is not None,
                 "accumulated_profiles": len(self.accumulated_profiles),
             }
+            # End() returns 0 for a cleanly closed profile. A non-zero code is
+            # NOT a reliable pass/fail signal: igProfileClosed auto-connects a
+            # polyline's coincident endpoints and reports a non-zero code (e.g.
+            # -103) even though the resulting region extrudes fine -- the same
+            # code also appears for a genuinely open profile that builds nothing.
+            # So we surface the code as a hint and tell callers to verify that
+            # the downstream feature actually produced geometry.
+            if isinstance(validation_code, int) and validation_code != 0:
+                result["note"] = (
+                    f"Profile.End returned {validation_code} (0 = clean close). "
+                    f"Often benign (e.g. auto-connected polyline endpoints), but "
+                    f"verify the next feature actually created geometry."
+                )
 
             # NOTE: We keep active_profile valid after closing so it can be used
             # by feature operations (extrude, revolve, etc.). The profile object
@@ -820,8 +858,8 @@ class SketchManager:
             # Only clear it when a new sketch is created.
 
             _logger.info(
-                f"Sketch closed (end_flags={end_flags}, "
-                f"accumulated_profiles={len(self.accumulated_profiles)})"
+                f"Sketch closed (end_flags={end_flags}, code={validation_code}, "
+                f"accumulated={len(self.accumulated_profiles)})"
             )
             return result
         except Exception as e:

--- a/src/solidedge_mcp/backends/validation.py
+++ b/src/solidedge_mcp/backends/validation.py
@@ -1,0 +1,63 @@
+"""Input validation helpers for MCP tools.
+
+Provides two small helpers used by the tool layer:
+
+- ``validate_numerics`` — guards numeric parameters against non-numbers,
+  NaN, and infinities before they are handed to COM calls.
+- ``validate_path`` — normalizes a filesystem path and optionally checks
+  that it exists.
+
+Both return error payloads in the same ``{"error": ...}`` shape that the
+rest of the tool layer uses, so callers can simply ``return err``.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Any
+
+
+def validate_numerics(**values: Any) -> dict[str, Any] | None:
+    """Validate that keyword values are finite real numbers.
+
+    ``None`` values are skipped (treated as "not provided") so optional
+    parameters can be forwarded directly. Booleans are rejected because they
+    are almost never an intended numeric input here.
+
+    Returns an error dict on the first invalid value, or ``None`` if all
+    values are valid.
+    """
+    for name, value in values.items():
+        if value is None:
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return {
+                "error": (
+                    f"Parameter '{name}' must be a number, "
+                    f"got {type(value).__name__}"
+                )
+            }
+        if not math.isfinite(float(value)):
+            return {"error": f"Parameter '{name}' must be finite, got {value!r}"}
+    return None
+
+
+def validate_path(
+    path: str, must_exist: bool = False
+) -> tuple[str, dict[str, Any] | None]:
+    """Normalize a filesystem path and optionally verify it exists.
+
+    Returns a ``(normalized_path, error)`` tuple. ``error`` is ``None`` on
+    success. When ``must_exist`` is true and the path is absent, an error
+    dict is returned alongside the normalized path.
+    """
+    if not isinstance(path, str) or not path.strip():
+        return path, {"error": "A non-empty file path is required"}
+
+    normalized = os.path.normpath(os.path.expanduser(os.path.expandvars(path)))
+
+    if must_exist and not os.path.exists(normalized):
+        return normalized, {"error": f"Path does not exist: {normalized}"}
+
+    return normalized, None

--- a/src/solidedge_mcp/tools/sketching.py
+++ b/src/solidedge_mcp/tools/sketching.py
@@ -29,8 +29,8 @@ def manage_sketch(
 
     For action='close': closed=True (default) validates the profile as a
     closed region (required for solids; welds polyline rectangles into a
-    region). The result includes 'valid' and 'validation_code' -- check
-    'valid' before building a feature. Pass closed=False for open profiles.
+    region). The result includes 'validation_code' (0 = clean close; other
+    values are a hint, not a hard failure). Pass closed=False for open profiles.
     """
     err = validate_numerics(x1=x1, y1=y1, x2=x2, y2=y2)
     if err:

--- a/src/solidedge_mcp/tools/sketching.py
+++ b/src/solidedge_mcp/tools/sketching.py
@@ -17,6 +17,7 @@ def manage_sketch(
     x2: float = 0.0,
     y2: float = 0.0,
     visible: bool = False,
+    closed: bool = True,
 ) -> dict[str, Any]:
     """Create, close, or configure a 2D sketch.
 
@@ -25,6 +26,11 @@ def manage_sketch(
 
     Named planes: 'Top','Front','Right','XY','XZ','YZ'.
     Coordinates in meters.
+
+    For action='close': closed=True (default) validates the profile as a
+    closed region (required for solids; welds polyline rectangles into a
+    region). The result includes 'valid' and 'validation_code' -- check
+    'valid' before building a feature. Pass closed=False for open profiles.
     """
     err = validate_numerics(x1=x1, y1=y1, x2=x2, y2=y2)
     if err:
@@ -33,7 +39,7 @@ def manage_sketch(
         case "create":
             return sketch_manager.create_sketch(plane)
         case "close":
-            return sketch_manager.close_sketch()
+            return sketch_manager.close_sketch(closed=closed)
         case "create_on_plane":
             return sketch_manager.create_sketch_on_plane_index(plane_index)
         case "set_axis":

--- a/tests/unit/test_features_base.py
+++ b/tests/unit/test_features_base.py
@@ -1,0 +1,111 @@
+"""Unit tests for the verifies_geometry decorator (honest feature status).
+
+The decorator keys on the body's FACE COUNT (and Models.Count for the first
+solid), because a failed feature still adds a feature-tree node but leaves the
+body's faces unchanged.
+"""
+
+from unittest.mock import MagicMock
+
+from solidedge_mcp.backends.features._base import FeatureManagerBase, verifies_geometry
+
+
+class _Counter:
+    def __init__(self, count):
+        self.Count = count
+
+
+class _Body:
+    def __init__(self, face_count):
+        self.face_count = face_count
+
+    def Faces(self, _query):
+        return _Counter(self.face_count)
+
+
+class _Model:
+    def __init__(self, body):
+        self.Body = body
+
+
+class _Models:
+    def __init__(self, count, body):
+        self.Count = count
+        self._body = body
+
+    def Item(self, _i):
+        return _Model(self._body)
+
+
+class _FakeDoc:
+    def __init__(self, models_count, face_count, faces_int=True):
+        body = _Body(face_count if faces_int else MagicMock())
+        self.Models = _Models(models_count, body)
+        self.body = body
+
+
+class _Mgr(FeatureManagerBase):
+    def __init__(self, doc):
+        dm = MagicMock()
+        dm.get_active_document.return_value = doc
+        super().__init__(dm, MagicMock())
+        self._doc = doc
+
+    @verifies_geometry
+    def make(self, *, new_faces):
+        # Simulate the COM feature changing (or not) the body's face count.
+        self._doc.body.face_count = new_faces
+        return {"status": "created", "type": "test"}
+
+    @verifies_geometry
+    def make_error(self):
+        return {"error": "boom"}
+
+
+def test_passes_through_when_faces_change():
+    mgr = _Mgr(_FakeDoc(models_count=1, face_count=6))
+    result = mgr.make(new_faces=8)  # a round added faces
+    assert result["status"] == "created"
+
+
+def test_downgrades_to_error_when_faces_unchanged():
+    mgr = _Mgr(_FakeDoc(models_count=1, face_count=6))
+    result = mgr.make(new_faces=6)  # no-op feature
+    assert "error" in result
+    assert result["faces_before"] == 6
+    assert result["faces_after"] == 6
+    assert result["attempted"] == "test"
+
+
+def test_base_feature_first_solid_counts_as_success():
+    # Models 0 -> 1 (faces 0 -> 6): the base solid appeared.
+    doc = _FakeDoc(models_count=0, face_count=0)
+    mgr = _Mgr(doc)
+
+    @verifies_geometry
+    def make_base(self):
+        doc.Models.Count = 1
+        doc.body.face_count = 6
+        return {"status": "created", "type": "base"}
+
+    result = make_base(mgr)
+    assert result["status"] == "created"
+
+
+def test_existing_error_is_not_rewritten():
+    mgr = _Mgr(_FakeDoc(models_count=1, face_count=6))
+    assert mgr.make_error() == {"error": "boom"}
+
+
+def test_conservative_when_faces_not_readable():
+    mgr = _Mgr(_FakeDoc(models_count=1, face_count=6, faces_int=False))
+    result = mgr.make(new_faces=6)
+    assert result["status"] == "created"  # cannot prove failure -> pass through
+
+
+def test_no_geometry_created_logic():
+    f = FeatureManagerBase._no_geometry_created
+    assert f((1, 6), (1, 6)) is True      # body unchanged
+    assert f((1, 6), (1, 8)) is False     # faces changed
+    assert f((0, 0), (1, 6)) is False     # base solid appeared
+    assert f((None, None), (None, None)) is False  # unknown -> no claim

--- a/tests/unit/test_query_physical_props.py
+++ b/tests/unit/test_query_physical_props.py
@@ -212,6 +212,7 @@ class TestGetUserPhysicalProperties:
 
         result = qm.get_user_physical_properties()
         assert result["status"] == "success"
+        assert result["source"] == "user_override"
         assert result["volume"] == 1.5e-5
         assert result["surface_area"] == 0.001
         assert result["mass"] == 0.12
@@ -224,21 +225,42 @@ class TestGetUserPhysicalProperties:
 
         result = qm.get_user_physical_properties()
         assert result["status"] == "success"
+        assert result["source"] == "user_override"
         assert result["volume"] == 1.0e-5
         assert result["surface_area"] == 0.002
         assert result["mass"] == 0.05
 
-    def test_non_tuple_result(self, query_mgr):
+    def test_non_tuple_result_falls_back_to_computed(self, query_mgr):
         qm, doc = query_mgr
         doc.GetUserPhysicalProperties.return_value = "unexpected"
+        qm.get_mass_properties = MagicMock(
+            return_value={"status": "computed", "mass": 0.44, "volume": 5.6e-5}
+        )
 
         result = qm.get_user_physical_properties()
-        assert result["status"] == "success"
-        assert "raw_result" in result
+        qm.get_mass_properties.assert_called_once()
+        assert result["source"] == "computed"
+        assert result["mass"] == 0.44
+        assert "note" in result
 
-    def test_com_error(self, query_mgr):
+    def test_com_fault_falls_back_to_computed(self, query_mgr):
+        # GetUserPhysicalProperties faults on a part with no user overrides;
+        # the method must compute from geometry instead of erroring.
         qm, doc = query_mgr
         doc.GetUserPhysicalProperties.side_effect = Exception("Not a part doc")
+        qm.get_mass_properties = MagicMock(
+            return_value={"status": "computed", "mass": 0.44}
+        )
+
+        result = qm.get_user_physical_properties(density=2700.0)
+        qm.get_mass_properties.assert_called_once_with(2700.0)
+        assert result["source"] == "computed"
+        assert "error" not in result
+
+    def test_fallback_error_propagates(self, query_mgr):
+        qm, doc = query_mgr
+        doc.GetUserPhysicalProperties.side_effect = Exception("no overrides")
+        qm.get_mass_properties = MagicMock(return_value={"error": "no body"})
 
         result = qm.get_user_physical_properties()
         assert "error" in result

--- a/tests/unit/test_sketching.py
+++ b/tests/unit/test_sketching.py
@@ -22,6 +22,66 @@ def sketch_mgr():
 
 
 # ============================================================================
+# CLOSE SKETCH  (validation-flag + honest validation-code reporting)
+# ============================================================================
+
+
+class TestCloseSketch:
+    def _profile(self, sm, end_ret=0):
+        profile = MagicMock()
+        profile.End.return_value = end_ret
+        sm.active_profile = profile
+        return profile
+
+    def test_no_active_sketch(self, sketch_mgr):
+        sm, _ = sketch_mgr
+        sm.active_profile = None
+        assert "error" in sm.close_sketch()
+
+    def test_closed_true_uses_igProfileClosed(self, sketch_mgr):
+        sm, _ = sketch_mgr
+        profile = self._profile(sm, end_ret=0)
+        result = sm.close_sketch(closed=True)
+        profile.End.assert_called_once_with(1)  # igProfileClosed
+        assert result["status"] == "closed"
+        assert result["validation_code"] == 0
+        assert "note" not in result  # clean close -> no hint
+
+    def test_closed_false_uses_igProfileDefault(self, sketch_mgr):
+        sm, _ = sketch_mgr
+        profile = self._profile(sm, end_ret=0)
+        sm.close_sketch(closed=False)
+        profile.End.assert_called_once_with(0)  # igProfileDefault
+
+    def test_refaxis_forces_revolve_flag(self, sketch_mgr):
+        sm, _ = sketch_mgr
+        profile = self._profile(sm, end_ret=0)
+        sm.active_refaxis = MagicMock()
+        sm.close_sketch(closed=True)
+        profile.End.assert_called_once_with(17)  # igProfileForRevolve
+
+    def test_nonzero_code_is_informational_not_failure(self, sketch_mgr):
+        # End() returns -103 for a polyline whose endpoints igProfileClosed
+        # auto-connects -- it still extrudes, so this must NOT be flagged as a
+        # failure. We surface the code as a hint only.
+        sm, _ = sketch_mgr
+        self._profile(sm, end_ret=-103)
+        result = sm.close_sketch(closed=True)
+        assert result["status"] == "closed"
+        assert result["validation_code"] == -103
+        assert "note" in result
+        assert "valid" not in result
+
+    def test_end_exception_surfaced(self, sketch_mgr):
+        sm, _ = sketch_mgr
+        profile = MagicMock()
+        profile.End.side_effect = Exception("COM boom")
+        sm.active_profile = profile
+        result = sm.close_sketch()
+        assert "error" in result
+
+
+# ============================================================================
 # PROJECT REF PLANE
 # ============================================================================
 

--- a/tests/unit/test_tools_sketching.py
+++ b/tests/unit/test_tools_sketching.py
@@ -48,6 +48,16 @@ class TestManageSketch:
         manage_sketch(action="set_axis", x1=0.0, y1=0.0, x2=0.1, y2=0.0)
         mock_mgr.set_axis_of_revolution.assert_called_once_with(0.0, 0.0, 0.1, 0.0)
 
+    def test_close_defaults_to_closed(self, mock_mgr):
+        mock_mgr.close_sketch.return_value = {"status": "closed"}
+        manage_sketch(action="close")
+        mock_mgr.close_sketch.assert_called_once_with(closed=True)
+
+    def test_close_passes_closed_false(self, mock_mgr):
+        mock_mgr.close_sketch.return_value = {"status": "closed"}
+        manage_sketch(action="close", closed=False)
+        mock_mgr.close_sketch.assert_called_once_with(closed=False)
+
     def test_unknown(self, mock_mgr):
         result = manage_sketch(action="bogus")
         assert "error" in result


### PR DESCRIPTION
## Summary

This PR fixes a set of bugs where Solid Edge operations **silently failed while reporting success**, plus a mass-property COM fault and the missing `validation` module that breaks import. All fixes were verified both by the unit suite and live against **Solid Edge 2025**.

## Fixes

### 1. Missing `validation` backend module (import break)
`master` imports `solidedge_mcp.backends.validation` (`validate_numerics`, `validate_path`) but the module is absent, so the package fails to import. Added it.

### 2. Rectangles/polylines silently produced no geometry
`close_sketch` validated profiles with `Profile.End(igProfileDefault=0)`, which does **not** weld a polyline's coincident endpoints into a region. A rectangle drawn as 4 separate lines therefore yielded **0 closed regions**, and the following extrude/revolve silently no-op'd while still returning `status: created`. (Circles worked only because a single closed curve needs no welding.)

- Fix: validate with `igProfileClosed` for solids (`close_sketch(closed=True)`, the default); revolve still uses `igProfileForRevolve`; pass `closed=False` for intentionally open profiles (sweep paths/surfaces).
- Stopped swallowing `End()` errors with `contextlib.suppress(BaseException)`; the result now reports `validation_code` as a hint (it is **not** a reliable pass/fail — a welded rectangle returns `-103` yet extrudes).
- **Live:** a 4-line rectangle now extrudes into a real body (`Models.Count 0 → 1`).

### 3. Features reported `status: created` without building geometry
Several feature calls silently no-op (e.g. on an open/invalid profile) without raising. Added a `@verifies_geometry` decorator (and a `verify_geometry_on_creators` class decorator) that snapshots the body before/after and, on apparent success, downgrades to an explicit error when no geometry was created.

- The reliable signal is the body's **face count**, not the feature-tree count — a *failed* feature still adds a `DesignEdgebarFeatures` node (observed `4 → 5` on a no-op), whereas the body's faces stay unchanged. `Models.Count` covers the base solid (`0 → 1`).
- Conservative: if counts can't be read as ints, or the document is a `unittest.mock` double, it passes through unchanged (never invents a failure).
- Applied to all material-changing creators: **Extrude, Revolve, Holes, Cutout, Primitive, Loft/Sweep/Helix**. Intentionally **not** applied to geometry-neutral creators (draft angle, cosmetic thread, surfaces, ref planes) where a success leaves the face count unchanged.
- **Live:** an open-profile extrude now returns an error (`faces 6 → 6`) instead of a false `created`.

### 4. `query_body('user_physical_properties')` faulted instead of returning mass
`get_user_physical_properties` called `PartDocument.GetUserPhysicalProperties()`, which returns **user-set overrides** and **faults** on a part that has none (the common case). It now falls back to properties **computed from geometry** via `ComputePhysicalPropertiesWithSpecifiedDensity` (the same path the working `solidedge://geometry/*` resources use), tagging the result with `source: user_override | computed`.

- **Live:** an r=30 h=20 cylinder now returns `source: computed`, volume `5.65e-5 m³`, mass `0.444 kg`, cog `(0,0,0.01)` instead of a COM fault.

### 5. Smaller fixes
- Clarified the `add_keypoint_constraint` docstring: keypoint indices are geometric 0-based (`0=start, 1=end, 2=midpoint`), **not** the `KeyPointType` enum (1/2) — verified live (no behavior change).
- Fixed a `UnicodeEncodeError` from the `kg/m³` glyph in a mass-properties log message on cp1251 consoles (log-only).

## Tests & verification

- **2170 unit tests pass**; `ruff` and `mypy --strict` clean.
- New unit tests for the closure flag/validation-code reporting and the geometry-verification decorator.
- Every fix additionally verified live against Solid Edge 2025 by exercising the patched backend directly.

## Out of scope (flagged, not fixed here)

Two pre-existing COM bugs were found while testing and are left for follow-up:
- **Sheet-metal feature creation** faults at COM (keyword args to `AddBaseContourFlange`, and SAFEARRAY profile-array marshaling), so no `.psm` body can be built — that's why geometry verification is **not** applied to sheet metal.
- **`create_box_by_center`** (and likely other primitives) faults at COM on SE 2025.
